### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ To make VS Code map the files on the server to the right files on your local mac
 ```json
 // server -> local
 "pathMappings": {
-  "/var/www/html": "${workspaceRoot}/www",
-  "/app": "${workspaceRoot}/app"
+  "/var/www/html": "${workspaceFolder}/www",
+  "/app": "${workspaceFolder}/app"
 }
 ```
 


### PR DESCRIPTION
Changed references to the predifined vscode variable "workspaceRoot" to "workspaceFolder" since it was deprecated.